### PR TITLE
add collection_pre_install dependency

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -60,6 +60,9 @@ jobs:
         shell: bash
         run: sudo apt update && sudo apt install libssh-dev
         if: ${{ matrix.entry.python == 3.12 }}
+      - name: Pre-install Ansible collections
+        if: ${{ inputs.collection_pre_install != '' }}
+        run: ansible-galaxy collection install ${{ inputs.collection_pre_install }}
       - name: Run tox integration tests
         run: >-
           python -m tox --ansible -e ${{ matrix.entry.name }} --conf

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -61,7 +61,7 @@ jobs:
         run: sudo apt update && sudo apt install libssh-dev
         if: ${{ matrix.entry.python == 3.12 }}
       - name: Pre install collections dependencies first so the collection install does not
-        run: ansible-galaxy collection install --pre ${{ inputs.collection_pre_install }} -p /home/runner/collections
+        run: ansible-galaxy collection install --pre ${{ inputs.collection_pre_install }} /home/runner/collections
         if: inputs.collection_pre_install != ''
       - name: Run tox integration tests
         run: >-

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -60,9 +60,9 @@ jobs:
         shell: bash
         run: sudo apt update && sudo apt install libssh-dev
         if: ${{ matrix.entry.python == 3.12 }}
-      - name: Pre-install Ansible collections
-        if: ${{ inputs.collection_pre_install != '' }}
-        run: ansible-galaxy collection install ${{ inputs.collection_pre_install }}
+      - name: Pre install collections dependencies first so the collection install does not
+        run: ansible-galaxy collection install --pre ${{ inputs.collection_pre_install }} -p /home/runner/collections
+        if: inputs.collection_pre_install != ''
       - name: Run tox integration tests
         run: >-
           python -m tox --ansible -e ${{ matrix.entry.name }} --conf

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,7 +1,12 @@
 ---
 name: Integration
 "on":
-  workflow_call: null
+  workflow_call:
+    inputs:
+      collection_pre_install:
+        required: false
+        type: string
+        default: ""
 jobs:
   tox-matrix:
     name: Matrix Integration


### PR DESCRIPTION
since netcommon is not a dependency for utils, but for accessing `ansible.netcommon.native` parser we need netcommon dependency as a result of which integration test are failing in the cli_parse [PR](https://github.com/ansible-collections/ansible.utils/pull/333/files)