### PR TITLE
Update ansible version for network integration workflow

### DIFF
--- a/.github/workflows/network_integration.yaml
+++ b/.github/workflows/network_integration.yaml
@@ -53,7 +53,8 @@ jobs:
       fail-fast: false
       matrix:
         ansible-version:
-          - stable-2.16
+          - stable-2.18
+          # - stable-2.16
           # - stable-2.15
           # - milestone
           # - devel


### PR DESCRIPTION
Update ansible version for network integration workflow to 2.18