### PR TITLE
pin ansible-compat to 24.10.0

### DIFF
--- a/.github/workflows/ansible_lint.yaml
+++ b/.github/workflows/ansible_lint.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Install ansible-lint from pip
         shell: bash
         run: |
-          pip install ansible-lint
+          pip install ansible-compat==24.10.0 ansible-lint
           ansible-lint --version
       - name: Run ansible-lint
         shell: bash


### PR DESCRIPTION
It appears the ansible-compat v25.0.0 seems to have broken ansible-lint.