### PR TITLE
Revert "pin ansible-compat to 24.10.0 (#39)"

### DIFF
--- a/.github/workflows/ansible_lint.yaml
+++ b/.github/workflows/ansible_lint.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Install ansible-lint from pip
         shell: bash
         run: |
-          pip install ansible-compat==24.10.0 ansible-lint
+          pip install ansible-lint
           ansible-lint --version
       - name: Run ansible-lint
         shell: bash


### PR DESCRIPTION
Fixes #55

This reverts commit 5834e014160052d939836b0c6c6ae070d4d13740.

This pin is no longer necessary.