### PR TITLE
Update ee-build workflow to fix push to GHCR step

### DIFF
--- a/.github/workflows/ee-build.yml
+++ b/.github/workflows/ee-build.yml
@@ -163,9 +163,9 @@ jobs:
         id: push_to_ghcr
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: ${{ env.EE }}
+          image: ${{ github.repository_owner }}/${{ env.EE }}
           tags: ${{ env.IMAGE_TAG }}
-          registry: ${{ env.IMAGE_REGISTRY }}/${{ github.repository_owner }}
+          registry: ${{ env.IMAGE_REGISTRY }}
 
       - name: Set push success flag
         if: success()


### PR DESCRIPTION
This change modifies the image and registry parameters. The image parameter should contain the namespace and ee name.

I noticed this while trying out the workflow in a sample collection. Here are the logs:

##[group]Run redhat-actions/push-to-registry@v2
2025-07-08T16:22:27.8860934Z with:
2025-07-08T16:22:27.8861110Z   image: hello_nora_ee
2025-07-08T16:22:27.8861293Z   tags: latest
2025-07-08T16:22:27.8861468Z   registry: ghcr.io/oraNod
2025-07-08T16:22:27.8861684Z   tls-verify: true
2025-07-08T16:22:27.8861855Z env:
2025-07-08T16:22:27.8862007Z   EE: hello_nora_ee
2025-07-08T16:22:27.8862196Z   EE_file: execution-environment.yml
2025-07-08T16:22:27.8862432Z   IMAGE_REGISTRY: ghcr.io
2025-07-08T16:22:27.8862622Z   IMAGE_TAG: latest
2025-07-08T16:22:27.8862853Z   REGISTRY_AUTH_FILE: /run/user/1001/containers/auth.json
2025-07-08T16:22:27.8863129Z ##[endgroup]
2025-07-08T16:22:27.9529073Z Creating temporary Podman image storage for pulling from Docker daemon
2025-07-08T16:22:27.9547651Z Storage driver is not 'overlay', so not overriding storage configuration
2025-07-08T16:22:27.9552716Z Combining image name "hello_nora_ee" and registry "ghcr.io/oraNod" to form registry path "ghcr.io/oraNod/hello_nora_ee"
2025-07-08T16:22:27.9554128Z 🔍 Checking if the given image is manifest or not.
2025-07-08T16:22:27.9577013Z ##[group]/usr/bin/podman version
2025-07-08T16:22:27.9584960Z [command]/usr/bin/podman version
2025-07-08T16:22:27.9785185Z Client:       Podman Engine
2025-07-08T16:22:27.9785623Z Version:      4.9.3
2025-07-08T16:22:27.9785931Z API Version:  4.9.3
2025-07-08T16:22:27.9786232Z Go Version:   go1.22.2
2025-07-08T16:22:27.9786566Z Built:        Thu Jan  1 00:00:00 1970
2025-07-08T16:22:27.9786952Z OS/Arch:      linux/amd64
2025-07-08T16:22:27.9821556Z ##[endgroup]
2025-07-08T16:22:27.9822283Z ##[group]/usr/bin/podman manifest exists hello_nora_ee:latest
2025-07-08T16:22:27.9824309Z [command]/usr/bin/podman manifest exists hello_nora_ee:latest
2025-07-08T16:22:28.0218485Z Error: localhost/hello_nora_ee:latest: image is not a manifest list
2025-07-08T16:22:28.0243003Z ##[endgroup]
2025-07-08T16:22:28.0244587Z 🔍 Checking if "hello_nora_ee:latest" present in the local Podman image storage
2025-07-08T16:22:28.0247519Z [command]/usr/bin/podman image exists hello_nora_ee:latest
2025-07-08T16:22:28.0732746Z Tag "hello_nora_ee:latest" found in Podman image storage
2025-07-08T16:22:28.0735645Z 🔍 Checking if "hello_nora_ee:latest" present in the local Docker image storage
2025-07-08T16:22:28.0737037Z ##[group]/usr/bin/podman --root /tmp/podman-from-docker-f1Otbb pull docker-daemon:hello_nora_ee:latest
2025-07-08T16:22:28.0740206Z [command]/usr/bin/podman --root /tmp/podman-from-docker-f1Otbb pull docker-daemon:hello_nora_ee:latest
2025-07-08T16:22:28.1152878Z Error: initializing source docker-daemon:hello_nora_ee:latest: loading image from docker engine: Error response from daemon: reference does not exist
2025-07-08T16:22:28.1178322Z ##[endgroup]
2025-07-08T16:22:28.1180608Z Tag "hello_nora_ee:latest" was found in the Podman image storage, but not in the Docker image storage. The image(s) will be pushed from Podman image storage.
2025-07-08T16:22:28.1182309Z ⏳ Pushing "hello_nora_ee:latest" to "ghcr.io/oraNod/hello_nora_ee:latest" respectively
2025-07-08T16:22:28.1184226Z [command]/usr/bin/podman push --quiet --digestfile hello_nora_ee-latest_digest.txt hello_nora_ee:latest ghcr.io/oraNod/hello_nora_ee:latest --tls-verify=true
2025-07-08T16:22:28.1591314Z Error: Invalid image name "ghcr.io/oraNod/hello_nora_ee:latest", unknown transport "ghcr.io/oraNod/hello_nora_ee"
2025-07-08T16:22:28.1615375Z Removing temporary Podman image storage for pulling from Docker daemon
2025-07-08T16:22:28.1617574Z [command]/usr/bin/podman --root /tmp/podman-from-docker-f1Otbb rmi -a -f
2025-07-08T16:22:28.1918190Z (node:8254) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
2025-07-08T16:22:28.1919555Z (Use `node --trace-deprecation ...` to show where the warning was created)
2025-07-08T16:22:28.1973706Z ##[error]podman exited with code 125
Error: Invalid image name "ghcr.io/oraNod/hello_nora_ee:latest", unknown transport "ghcr.io/oraNod/hello_nora_ee"

It appears that the workflow is constructing an invalid image name. Podman is interpreting part of the registry URL as a transport.