### PR TITLE
Allow passing additional matrix entries in unit and sanity workflows

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -38,8 +38,8 @@ jobs:
 
           merged=$(
             jq -c -n \
-              --argjson a "${{ steps.generate-matrix.outputs.envlist }}" \
-              --argjson b "${{ inputs.extra_matrix_entries || '[]' }}" \
+              --argjson a '${{ steps.generate-matrix.outputs.envlist }}' \
+              --argjson b '${{ inputs.extra_matrix_entries || '[]' }}' \
               '$a + $b'
           )
           echo "envlist=$merged" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -34,7 +34,6 @@ jobs:
         run: |
           echo "Generated matrix: ${{ steps.generate-matrix.outputs.envlist }}"
           echo "Extra matrix: ${{ inputs.extra_matrix_entries }}"
-          echo "Merged matrix:"
 
           merged=$(
             jq -c -n \
@@ -42,6 +41,7 @@ jobs:
               --argjson b '${{ inputs.extra_matrix_entries || '[]' }}' \
               '$a + $b'
           )
+          echo "Merged matrix: $merged"
           echo "envlist=$merged" >> "$GITHUB_OUTPUT"
     outputs:
       envlist: "${{ steps.merge-matrix.outputs.envlist }}"

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -1,7 +1,12 @@
 ---
 name: Ansible sanity
+
 "on":
-  workflow_call: null
+  workflow_call:
+    inputs:
+      extra_matrix_entries:
+        required: false
+        type: string
 jobs:
   tox-matrix:
     name: Matrix Sanity
@@ -24,6 +29,20 @@ jobs:
         run: >
           python -m tox --ansible --gh-matrix --matrix-scope sanity --conf
           tox-ansible.ini
+      - name: Merge matrix with extra entries
+        id: merge-matrix
+        run: |
+          echo "Generated matrix: ${{ steps.generate-matrix.outputs.envlist }}"
+          echo "Extra matrix: ${{ inputs.extra_matrix_entries }}"
+          echo "Merged matrix:"
+
+          merged=$(
+            jq -c -n \
+              --argjson a "${{ steps.generate-matrix.outputs.envlist }}" \
+              --argjson b "${{ inputs.extra_matrix_entries || '[]' }}" \
+              '$a + $b'
+          )
+          echo "envlist=$merged" >> "$GITHUB_OUTPUT"
     outputs:
       envlist: "${{ steps.generate-matrix.outputs.envlist }}"
   test:

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -44,7 +44,7 @@ jobs:
           )
           echo "envlist=$merged" >> "$GITHUB_OUTPUT"
     outputs:
-      envlist: "${{ steps.generate-matrix.outputs.envlist }}"
+      envlist: "${{ steps.merge-matrix.outputs.envlist }}"
   test:
     needs: tox-matrix
     strategy:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -7,6 +7,9 @@ name: Ansible Unit
         required: false
         type: string
         default: ""
+      extra_matrix_entries:
+        required: false
+        type: string
 jobs:
   tox-matrix:
     name: Matrix Unit
@@ -29,6 +32,20 @@ jobs:
         run: >
           python -m tox --ansible --gh-matrix --matrix-scope unit --conf
           tox-ansible.ini
+      - name: Merge matrix with extra entries
+        id: merge-matrix
+        run: |
+          echo "Generated matrix: ${{ steps.generate-matrix.outputs.envlist }}"
+          echo "Extra matrix: ${{ inputs.extra_matrix_entries }}"
+          echo "Merged matrix:"
+
+          merged=$(
+            jq -c -n \
+              --argjson a "${{ steps.generate-matrix.outputs.envlist }}" \
+              --argjson b "${{ inputs.extra_matrix_entries || '[]' }}" \
+              '$a + $b'
+          )
+          echo "envlist=$merged" >> "$GITHUB_OUTPUT"
     outputs:
       envlist: "${{ steps.generate-matrix.outputs.envlist }}"
   test:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -37,7 +37,6 @@ jobs:
         run: |
           echo "Generated matrix: ${{ steps.generate-matrix.outputs.envlist }}"
           echo "Extra matrix: ${{ inputs.extra_matrix_entries }}"
-          echo "Merged matrix:"
 
           merged=$(
             jq -c -n \
@@ -45,6 +44,7 @@ jobs:
               --argjson b '${{ inputs.extra_matrix_entries || '[]' }}' \
               '$a + $b'
           )
+          echo "Merged matrix: $merged"
           echo "envlist=$merged" >> "$GITHUB_OUTPUT"
     outputs:
       envlist: "${{ steps.merge-matrix.outputs.envlist }}"

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -41,8 +41,8 @@ jobs:
 
           merged=$(
             jq -c -n \
-              --argjson a "${{ steps.generate-matrix.outputs.envlist }}" \
-              --argjson b "${{ inputs.extra_matrix_entries || '[]' }}" \
+              --argjson a '${{ steps.generate-matrix.outputs.envlist }}' \
+              --argjson b '${{ inputs.extra_matrix_entries || '[]' }}' \
               '$a + $b'
           )
           echo "envlist=$merged" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -47,7 +47,7 @@ jobs:
           )
           echo "envlist=$merged" >> "$GITHUB_OUTPUT"
     outputs:
-      envlist: "${{ steps.generate-matrix.outputs.envlist }}"
+      envlist: "${{ steps.merge-matrix.outputs.envlist }}"
   test:
     needs: tox-matrix
     strategy:


### PR DESCRIPTION
This PR adds to ability to extend tox-ansible generated matrix. Currently, ansible-core==2.16 is EoLed for upstream, but is still the core version in AAP 2.5 which is still under support. Collections with min core requirement >=2.16 require this change.

Ref PR: https://github.com/NilashishC/cisco.nxos/pull/16/files