### PR TITLE
feat: add optional Galaxy server auth inputs to sanity, unit, and integration workflows

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,7 +1,26 @@
 ---
 name: Integration
 "on":
-  workflow_call: null
+  workflow_call:
+    inputs:
+      galaxy_server_url:
+        description: >-
+          URL of an additional Galaxy server (e.g. Automation Hub).
+          When set, the server is registered as "certified" and placed
+          before the default Galaxy server in ANSIBLE_GALAXY_SERVER_LIST.
+        required: false
+        type: string
+      galaxy_server_auth_url:
+        description: >-
+          SSO / token endpoint for the additional Galaxy server
+          (e.g. the Red Hat SSO endpoint for Automation Hub).
+        required: false
+        type: string
+    secrets:
+      galaxy_server_token:
+        description: >-
+          Auth token for the additional Galaxy server.
+        required: false
 jobs:
   tox-matrix:
     name: Matrix Integration
@@ -61,3 +80,8 @@ jobs:
           tox-ansible.ini
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          ANSIBLE_GALAXY_SERVER_LIST: >-
+            ${{ inputs.galaxy_server_url != '' && 'certified,galaxy' || '' }}
+          ANSIBLE_GALAXY_SERVER_CERTIFIED_URL: ${{ inputs.galaxy_server_url }}
+          ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN: ${{ secrets.galaxy_server_token }}
+          ANSIBLE_GALAXY_SERVER_CERTIFIED_AUTH_URL: ${{ inputs.galaxy_server_auth_url }}

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -7,6 +7,24 @@ name: Ansible sanity
       extra_matrix_entries:
         required: false
         type: string
+      galaxy_server_url:
+        description: >-
+          URL of an additional Galaxy server (e.g. Automation Hub).
+          When set, the server is registered as "certified" and placed
+          before the default Galaxy server in ANSIBLE_GALAXY_SERVER_LIST.
+        required: false
+        type: string
+      galaxy_server_auth_url:
+        description: >-
+          SSO / token endpoint for the additional Galaxy server
+          (e.g. the Red Hat SSO endpoint for Automation Hub).
+        required: false
+        type: string
+    secrets:
+      galaxy_server_token:
+        description: >-
+          Auth token for the additional Galaxy server.
+        required: false
 jobs:
   tox-matrix:
     name: Matrix Sanity
@@ -72,3 +90,8 @@ jobs:
           tox-ansible.ini
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          ANSIBLE_GALAXY_SERVER_LIST: >-
+            ${{ inputs.galaxy_server_url != '' && 'certified,galaxy' || '' }}
+          ANSIBLE_GALAXY_SERVER_CERTIFIED_URL: ${{ inputs.galaxy_server_url }}
+          ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN: ${{ secrets.galaxy_server_token }}
+          ANSIBLE_GALAXY_SERVER_CERTIFIED_AUTH_URL: ${{ inputs.galaxy_server_auth_url }}

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -10,6 +10,24 @@ name: Ansible Unit
       extra_matrix_entries:
         required: false
         type: string
+      galaxy_server_url:
+        description: >-
+          URL of an additional Galaxy server (e.g. Automation Hub).
+          When set, the server is registered as "certified" and placed
+          before the default Galaxy server in ANSIBLE_GALAXY_SERVER_LIST.
+        required: false
+        type: string
+      galaxy_server_auth_url:
+        description: >-
+          SSO / token endpoint for the additional Galaxy server
+          (e.g. the Red Hat SSO endpoint for Automation Hub).
+        required: false
+        type: string
+    secrets:
+      galaxy_server_token:
+        description: >-
+          Auth token for the additional Galaxy server.
+        required: false
 jobs:
   tox-matrix:
     name: Matrix Unit
@@ -83,3 +101,8 @@ jobs:
           tox-ansible.ini
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          ANSIBLE_GALAXY_SERVER_LIST: >-
+            ${{ inputs.galaxy_server_url != '' && 'certified,galaxy' || '' }}
+          ANSIBLE_GALAXY_SERVER_CERTIFIED_URL: ${{ inputs.galaxy_server_url }}
+          ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN: ${{ secrets.galaxy_server_token }}
+          ANSIBLE_GALAXY_SERVER_CERTIFIED_AUTH_URL: ${{ inputs.galaxy_server_auth_url }}


### PR DESCRIPTION
## Summary

- Adds three optional parameters (`galaxy_server_url`, `galaxy_server_auth_url` inputs and `galaxy_server_token` secret) to the **sanity**, **unit**, and **integration** reusable workflows.
- When `galaxy_server_url` is provided, `ANSIBLE_GALAXY_SERVER_LIST` is set to `certified,galaxy` and the corresponding `ANSIBLE_GALAXY_SERVER_CERTIFIED_URL`, `_TOKEN`, and `_AUTH_URL` env vars are populated on the tox run step. No temporary files are created.
- All parameters are optional and fully backward-compatible — callers that don't pass them see no change in behavior.

## Motivation

Collections that depend on certified content hosted on Automation Hub (or other private Galaxy servers) currently cannot use these reusable workflows because `ansible-galaxy` / `ade install` fails to resolve dependencies that require authentication. This forces downstream repos to inline the entire sanity/unit/integration workflow just to inject authentication.

With this change, callers can simply pass the server URL and token:

```yaml
jobs:
  sanity:
    uses: ansible/ansible-content-actions/.github/workflows/sanity.yaml@main
    with:
      galaxy_server_url: https://console.redhat.com/api/automation-hub/content/published/
      galaxy_server_auth_url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
    secrets:
      galaxy_server_token: ${{ secrets.AH_TOKEN }}
```

## Test plan

- [ ] Verify existing callers that don't pass the new inputs continue to work unchanged (empty env vars are harmless)
- [ ] Confirm no temporary files are created or left behind

Made-with: Cursor