### PR TITLE
Close Stale Items | Add permission to overwrite cache in case of operations limit

### DIFF
--- a/.github/workflows/close_stale_issues_pr.yml
+++ b/.github/workflows/close_stale_issues_pr.yml
@@ -49,6 +49,8 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      actions: write
+      contents: read
     steps:
       - name: Close stale issues and PRs
         uses: actions/stale@v10.2.0


### PR DESCRIPTION
Referencing the following issue: https://github.com/actions/stale/issues/1131 
Same was seen in the following run where daily limit is reached but cache is not overridden:
https://github.com/ansible-collections/cisco.iosxr/actions/runs/25469372121/job/74729710453
```
Warning: Error delete _state: [403] Resource not accessible by integration - https://docs.github.com/rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/cisco.iosxr/cisco.iosxr --files-from manifest.txt --use-compress-program zstdmt
Failed to save: Unable to reserve cache with key _state, another job may be creating this cache.
```
This PR resolves that by providing the right permissions as presented in the issue.