### PR TITLE
fix: pin actions to their commit sha

### DIFF
--- a/.github/actions/ansible_validate_changelog/action.yaml
+++ b/.github/actions/ansible_validate_changelog/action.yaml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Setup python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.14"
     - name: Install python dependencies

--- a/.github/actions/generate-tox-ansible-matrix/action.yaml
+++ b/.github/actions/generate-tox-ansible-matrix/action.yaml
@@ -16,7 +16,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: true
 
@@ -24,13 +24,13 @@ runs:
     # https://github.com/actions/runner/issues/1070
     - name: Fail early if no scope was provided for matrix generation
       if: ${{ inputs.scope == '' }}
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           core.setFailed('A scope needs to be provided to generate matrix.')
 
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v8.1.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         version: "latest"
 

--- a/.github/actions/run-ansible-lint/action.yaml
+++ b/.github/actions/run-ansible-lint/action.yaml
@@ -34,7 +34,7 @@ runs:
 
     - name: Set up Python
       if: inputs.setup_python == 'true'
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         cache: pip
         cache-dependency-path: ${{ inputs.working_directory }}/.git/ansible-lint-requirements.txt

--- a/.github/actions/run-sanity/action.yaml
+++ b/.github/actions/run-sanity/action.yaml
@@ -17,7 +17,7 @@ runs:
     # https://github.com/actions/runner/issues/1070
     - name: Fail early if no scope was provided for matrix generation
       if: ${{ inputs.test-env == '' }}
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           core.setFailed('The input test-env (e.g., unit-py3.9-2.14) is required for this action to run.')
@@ -30,7 +30,7 @@ runs:
         echo "py_version=$output" >> $GITHUB_OUTPUT
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "${{ steps.get-python-version.outputs.py_version}}"
 

--- a/.github/actions/run-unit-galaxy/action.yaml
+++ b/.github/actions/run-unit-galaxy/action.yaml
@@ -17,7 +17,7 @@ runs:
     # https://github.com/actions/runner/issues/1070
     - name: Fail early if no scope was provided for matrix generation
       if: ${{ inputs.test-env == '' }}
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           core.setFailed('The input test-env (e.g., unit-py3.9-2.14) is required for this action to run.')
@@ -30,7 +30,7 @@ runs:
         echo "py_version=$output" >> $GITHUB_OUTPUT
 
     - name: Set up Python ${{ steps.get-python-version.outputs.py_version}}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "${{ steps.get-python-version.outputs.py_version}}"
 

--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -11,5 +11,5 @@ on:
 
 jobs:
   ack:
-    uses: ansible/team-devtools/.github/workflows/ack.yml@main
+    uses: ansible/team-devtools/.github/workflows/ack.yml@e7604b7f0f487584a2264c09a0df1524fe2be49e # v26.4.0
     secrets: inherit

--- a/.github/workflows/ansible_lint.yaml
+++ b/.github/workflows/ansible_lint.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Ansible Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "${{github.event.pull_request.head.ref}}"
           repository: "${{ github.event.pull_request.head.repo.full_name }}"
@@ -38,7 +38,7 @@ jobs:
           fi
       - name: Set up Python
         if: inputs.setup_python == 'true'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           cache: pip
           cache-dependency-path: ${{ steps.inputs.outputs.working_directory }}/.git/ansible-lint-requirements.txt

--- a/.github/workflows/build_import.yaml
+++ b/.github/workflows/build_import.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Ensure ansible-core and galaxy-importer is installed
         shell: bash

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -9,10 +9,10 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog')"
     steps:
       - name: Checkout the collection repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "${{ github.event.pull_request.head.sha }}"
           fetch-depth: "0"
       - name: Validate changelog
         uses: >-
-          ansible/ansible-content-actions/.github/actions/ansible_validate_changelog@main
+          ./github/actions/ansible_validate_changelog

--- a/.github/workflows/check_label.yaml
+++ b/.github/workflows/check_label.yaml
@@ -15,8 +15,8 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-      - uses: release-drafter/release-drafter@v7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
         if: "${{ github.event_name == 'pull_request' }}"
         with:
           disable-autolabeler: false
@@ -26,7 +26,7 @@ jobs:
         continue-on-error: true
       - name: Verify PR label action
         if: "${{ github.event_name == 'pull_request' }}"
-        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        uses: jesusvasquez333/verify-pr-label-action@657d111bbbe13e22bbd55870f1813c699bde1401 # v1.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: >-
@@ -37,14 +37,14 @@ jobs:
           disable-reviews: true
       - name: Update release notes if this is already merged
         if: github.event.pull_request.merged == true
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Add issue or pull-request to 'devtools' project
         env:
           BOT_PAT: "${{ secrets.BOT_PAT }}"
         if: env.BOT_PAT != null
-        uses: actions/add-to-project@main
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: "https://github.com/orgs/ansible/projects/86"
           github-token: "${{ secrets.BOT_PAT }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,11 +17,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   self-ansible-lint:
     uses: ./.github/workflows/ansible_lint.yaml
   self-build-import:
@@ -48,6 +48,6 @@ jobs:
       - self-integration
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/close_stale_issues_pr.yml
+++ b/.github/workflows/close_stale_issues_pr.yml
@@ -53,7 +53,7 @@ jobs:
       contents: read
     steps:
       - name: Close stale issues and PRs
-        uses: actions/stale@v10.2.0
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           days-before-stale: ${{ inputs.days-before-stale }}
           days-before-close: ${{ inputs.days-before-close }}

--- a/.github/workflows/cml_lab_create.yaml
+++ b/.github/workflows/cml_lab_create.yaml
@@ -36,7 +36,7 @@ jobs:
     environment: integration
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -70,7 +70,7 @@ jobs:
           echo "path=$topo_abs" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/cml_lab_destroy.yaml
+++ b/.github/workflows/cml_lab_destroy.yaml
@@ -25,7 +25,7 @@ jobs:
     environment: integration_destroy
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
           echo "title=$clean_title" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/cml_network_integration.yaml
+++ b/.github/workflows/cml_network_integration.yaml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: "0"
 
       - name: Set up Python ${{ inputs.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ inputs.python-version }}
 
@@ -71,7 +71,7 @@ jobs:
         if: ${{ !contains(inputs.ansible_version, 'devel') && !contains(inputs.ansible_version, 'milestone') }}
 
       - name: Checkout ansible-core (${{ inputs.ansible_version }}) - Branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ansible/ansible
           ref: ${{ inputs.ansible_version }}

--- a/.github/workflows/draft_release.yaml
+++ b/.github/workflows/draft_release.yaml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: push
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "${{ inputs.repo }}"
           fetch-depth: 0
           token: "${{ secrets.BOT_PAT }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
       - name: "Install antsibull-changelog, antsichaut"
@@ -32,7 +32,7 @@ jobs:
           --disable-pip-version-check
       - name: Run release drafter
         id: release_drafter
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Remove the v prefix from the release drafter version
@@ -43,7 +43,7 @@ jobs:
         run: 'antsibull-changelog release -v --version "${{ env.VERSION }}"'
       - name: Get previous tag
         id: previoustag
-        uses: WyriHaximus/github-action-get-previous-tag@master
+        uses: WyriHaximus/github-action-get-previous-tag@61819f33034117e6c686e6a31dba995a85afc9de # v2.0.0
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Generate changelog.yaml

--- a/.github/workflows/ee-build.yml
+++ b/.github/workflows/ee-build.yml
@@ -26,7 +26,7 @@ jobs:
     environment: test
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
@@ -64,7 +64,7 @@ jobs:
     environment: ${{ github.event_name }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -99,7 +99,7 @@ jobs:
           echo $GITHUB_ENV
 
       - name: Login to ghcr
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ github.actor }}
@@ -154,14 +154,14 @@ jobs:
           echo "</details>" >> $COMMANDS_FILE
 
       - name: Upload build artifact
-        uses: coactions/upload-artifact@v4
+        uses: coactions/upload-artifact@ec1957e16e4ecd304d3a115907ccb4ba5f636e9d # v4.0.22
         with:
           name: commands-${{ env.EE }}
           path: ./commands-${{ env.EE }}.txt
 
       - name: Push To GHCR
         id: push_to_ghcr
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
         with:
           image: ${{ env.EE }}
           tags: ${{ env.IMAGE_TAG }}
@@ -183,13 +183,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Post Comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -7,16 +7,16 @@ jobs:
     name: Matrix Integration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "${{github.event.pull_request.head.ref}}"
           repository: "${{ github.event.pull_request.head.repo.full_name }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
       - name: "Check for tox-ansible.ini file, else add default"
-        uses: ansible/ansible-content-actions/.github/actions/add_tox_ansible@main
+        uses: ./.github/actions/add_tox_ansible
       - name: "Install tox-ansible, includes tox"
         run: "python -m pip install git+https://github.com/ansible/tox-ansible.git"
       - name: Generate matrix
@@ -35,16 +35,16 @@ jobs:
     name: "${{ matrix.entry.name }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "${{ github.event.pull_request.head.sha }}"
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "${{ matrix.entry.python }}"
       - name: "Check for tox-ansible.ini file, else add default"
-        uses: ansible/ansible-content-actions/.github/actions/add_tox_ansible@main
+        uses: ./.github/actions/add_tox_ansible
       - name: "Install tox-ansible, includes tox"
         run: python -m pip install tox-ansible
       - name: Install build toolchain and openssl headers on Linux

--- a/.github/workflows/network_integration.yaml
+++ b/.github/workflows/network_integration.yaml
@@ -84,7 +84,7 @@ jobs:
         if: ${{ inputs.dry_run }}
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -96,7 +96,7 @@ jobs:
         if: ${{ !contains(matrix.ansible-version, 'devel') && !contains(matrix.ansible-version, 'milestone') }}
 
       - name: Checkout ansible-core (${{ matrix.ansible-version }}) - Branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ansible/ansible
           ref: ${{ matrix.ansible-version }}
@@ -302,7 +302,7 @@ jobs:
 
       - name: Upload logs
         if: ${{ !inputs.dry_run }}
-        uses: coactions/upload-artifact@v4
+        uses: coactions/upload-artifact@ec1957e16e4ecd304d3a115907ccb4ba5f636e9d # v4.0.22
         with:
           name: logs-${{ matrix.ansible-version }}-py${{ matrix.python-version }}
           path: /home/runner/test_logs/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ name: Release collection
         required: false
 jobs:
   release_automation_hub:
-    uses: ansible/ansible-content-actions/.github/workflows/release_ah.yaml@main
+    uses: ./.github/workflows/release_ah.yaml
     with:
       environment: release
     secrets:
@@ -34,7 +34,7 @@ jobs:
       ah_client_id: ${{ secrets.ah_client_id }}
       ah_client_secret: ${{ secrets.ah_client_secret }}
   release_galaxy:
-    uses: ansible/ansible-content-actions/.github/workflows/release_galaxy.yaml@main
+    uses: ./.github/workflows/release_galaxy.yaml
     needs:
       - release_automation_hub
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           echo "major=${major}" >> $GITHUB_OUTPUT
 
       - name: Check out src from Git
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/release_ah.yaml
+++ b/.github/workflows/release_ah.yaml
@@ -39,7 +39,7 @@ jobs:
           echo "Provide 'ah_token' OR both 'ah_client_id' and 'ah_client_secret'." 1>&2
           exit 1
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Ansible
         run: |

--- a/.github/workflows/release_galaxy.yaml
+++ b/.github/workflows/release_galaxy.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Galaxy release
     environment: "${{ inputs.environment }}"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build the collection
         run: |
           ansible-galaxy collection build -v --force

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -12,18 +12,18 @@ jobs:
     name: Matrix Sanity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "${{github.event.pull_request.head.ref}}"
           repository: "${{ github.event.pull_request.head.repo.full_name }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
       - name: "Install tox-ansible, includes tox"
         run: "python -m pip install tox-ansible"
       - name: "Check for tox-ansible.ini file, else add default"
-        uses: ansible/ansible-content-actions/.github/actions/add_tox_ansible@main
+        uses: ./.github/actions/add_tox_ansible
       - name: Generate matrix
         id: generate-matrix
         run: >
@@ -54,18 +54,18 @@ jobs:
     name: "${{ matrix.entry.name }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "${{ github.event.pull_request.head.sha }}"
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "${{ matrix.entry.python }}"
       - name: "Install tox-ansible, includes tox"
         run: python -m pip install tox-ansible
       - name: "Check for tox-ansible.ini file, else add default"
-        uses: ansible/ansible-content-actions/.github/actions/add_tox_ansible@main
+        uses: ./.github/actions/add_tox_ansible
       - name: Run tox sanity tests
         run: >-
           python -m tox --ansible -e ${{ matrix.entry.name }} --conf

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -46,13 +46,13 @@ jobs:
     if: ${{ !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'safe to test') }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           show-progress: false
 
       - name: Set up Python ${{ inputs.python_version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ inputs.python_version }}
 
@@ -104,7 +104,7 @@ jobs:
         run: ${{ inputs.test_command }}
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@master
+        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -15,16 +15,16 @@ jobs:
     name: Matrix Unit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "${{github.event.pull_request.head.ref}}"
           repository: "${{ github.event.pull_request.head.repo.full_name }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
       - name: "Check for tox-ansible.ini file, else add default"
-        uses: ansible/ansible-content-actions/.github/actions/add_tox_ansible@main
+        uses: ./.github/actions/add_tox_ansible
       - name: "Install tox-ansible, includes tox"
         run: "python -m pip install tox-ansible"
       - name: Generate matrix
@@ -57,18 +57,18 @@ jobs:
     name: "${{ matrix.entry.name }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "${{ github.event.pull_request.head.sha }}"
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "${{ matrix.entry.python }}"
       - name: "Install tox-ansible, includes tox"
         run: python -m pip install tox-ansible
       - name: "Check for tox-ansible.ini file, else add default"
-        uses: ansible/ansible-content-actions/.github/actions/add_tox_ansible@main
+        uses: ./.github/actions/add_tox_ansible
       - name: Install build toolchain and openssl headers on Linux
         shell: bash
         run: sudo apt update && sudo apt install build-essential libssl-dev

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ansible/actions//config/renovate.json"]
+  "extends": [
+    "github>ansible/actions//config/renovate.json",
+    "helpers:pinGitHubActionDigests"
+  ]
 }


### PR DESCRIPTION
Hi there,

I noticed that no actions in your workflows are pinned to their commit sha. This is a bit of an open door for supply chain attacks as we have recently seen, for example, with trivy.

With this PR all actions get pinned to their commit sha with the actual version as comment. This format is supported by dependabot and renovate.

Some actions where using dependencies from `ansible/ansible-content-actions@main`. I've changed them to reference the local path instead, so that their version matches the one from the caller.

I've also noticed, some actions are referenced from github.com/ansible-network/github_actions which doesn't seem to make releases or tags. I'd recommend pinning those to commit shas as well and it might be a good idea to create releases there as well.

And last but not least, I'd recommend linting the workflow and actions with [zizmor](https://github.com/zizmorcore/zizmor). When linting the actions, there are currently 36 medium and 52 high findings that should be addressed. But that's out of the scope of this PR.