### PR TITLE
Adding reusable workflow for codecoerage for network collections

### DIFF
--- a/.github/workflows/coverage_network_devices.yml
+++ b/.github/workflows/coverage_network_devices.yml
@@ -1,0 +1,64 @@
+name: CodeCoverage
+on:
+  workflow_call:
+    inputs:
+      collection_pre_install:
+        required: true
+        type: string
+jobs:
+  codecoverage:
+    env:
+      PY_COLORS: "1"
+      source_directory: "./source"
+      python_version: "3.10"
+      ansible_version: "latest"
+      os: "ubuntu-latest"
+    runs-on: ubuntu-latest
+
+    name: "Code Coverage | Python 3.10"
+    steps:
+      - name: Checkout the collection repository
+        uses: ansible-network/github_actions/.github/actions/checkout_dependency@main
+        with:
+          path: ${{ env.source_directory }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: "0"
+
+      - name: Set up Python ${{ env.python_version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.python_version }}
+
+      - name: Install ansible-core (${{ env.ansible-version }})
+        run: python3 -m pip install ansible-core pytest pytest-cov pytest-ansible-units pytest-forked pytest-xdist
+
+      - name: Read collection metadata from galaxy.yml
+        id: identify
+        uses: ansible-network/github_actions/.github/actions/identify_collection@main
+        with:
+          source_path: ${{ env.source_directory }}
+
+      - name: Build and install the collection
+        uses: ansible-network/github_actions/.github/actions/build_install_collection@main
+        with:
+          install_python_dependencies: true
+          source_path: ${{ env.source_directory }}
+          collection_path: ${{ steps.identify.outputs.collection_path }}
+          tar_file: ${{ steps.identify.outputs.tar_file }}
+
+      - name: Print the ansible version
+        run: ansible --version
+
+      - name: Print the python dependencies
+        run: python3 -m pip list
+
+      - name: Run Coverage tests
+        run: |
+          pytest tests/unit -v --cov-report xml --cov=./
+        working-directory: ${{ steps.identify.outputs.collection_path }}
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ${{ steps.identify.outputs.collection_path }}
+          fail_ci_if_error: false

--- a/.github/workflows/coverage_network_devices.yml
+++ b/.github/workflows/coverage_network_devices.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
 
-      - name: Install ansible-core 
+      - name: Install ansible-core
         run: python3 -m pip install ansible-core pytest pytest-cov pytest-ansible-units pytest-forked pytest-xdist
 
       - name: Read collection metadata from galaxy.yml

--- a/.github/workflows/coverage_network_devices.yml
+++ b/.github/workflows/coverage_network_devices.yml
@@ -10,12 +10,10 @@ jobs:
     env:
       PY_COLORS: "1"
       source_directory: "./source"
-      python_version: "3.10"
-      ansible_version: "latest"
-      os: "ubuntu-latest"
+      python_version: "3.12"
     runs-on: ubuntu-latest
 
-    name: "Code Coverage | Python 3.10"
+    name: "Code Coverage | Python 3.12"
     steps:
       - name: Checkout the collection repository
         uses: ansible-network/github_actions/.github/actions/checkout_dependency@main
@@ -25,11 +23,11 @@ jobs:
           fetch-depth: "0"
 
       - name: Set up Python ${{ env.python_version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.python_version }}
 
-      - name: Install ansible-core (${{ env.ansible-version }})
+      - name: Install ansible-core 
         run: python3 -m pip install ansible-core pytest pytest-cov pytest-ansible-units pytest-forked pytest-xdist
 
       - name: Read collection metadata from galaxy.yml
@@ -58,7 +56,7 @@ jobs:
         working-directory: ${{ steps.identify.outputs.collection_path }}
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v6
         with:
           directory: ${{ steps.identify.outputs.collection_path }}
           fail_ci_if_error: false


### PR DESCRIPTION
This PR adds  reusable workflow for generating codecov report for all nework collection and uploading it to codecov

this workflow was [here](https://github.com/ansible-network/github_actions/blob/main/.github/workflows/coverage_network_devices.yml) originally , but moving to this repo as all other reusable workflows are added here