### PR TITLE
chore: bump python version to 3.13 from 3.12 in cml_network_integration.yaml file

### DIFF
--- a/.github/workflows/cml_network_integration.yaml
+++ b/.github/workflows/cml_network_integration.yaml
@@ -18,7 +18,7 @@ on:
         default: libssh
       python-version:
         default: >-
-          3.12
+          3.13
         description: Python version to provision in the VM
         required: false
         type: string


### PR DESCRIPTION
Upgrades python version to 3.13 from 3.12 in cml_network_integration.yaml file.