### PR TITLE
feat: add working_directory input to EE build workflow for matrix support

### DIFF
--- a/.github/workflows/ee-build.yml
+++ b/.github/workflows/ee-build.yml
@@ -9,6 +9,11 @@ on:
         description: The registry to which the image will be pushed.
         required: true
         type: string
+      working_directory:
+        description: The directory containing the EE files.
+        required: false
+        type: string
+        default: "."
     secrets:
       registry_username:
         required: true
@@ -17,6 +22,9 @@ on:
       registry_redhat_username:
         required: false
       registry_redhat_password:
+        required: false
+      ah_token:
+        description: Automation Hub token passed to ansible-builder as a build arg.
         required: false
 
 jobs:
@@ -59,7 +67,7 @@ jobs:
 
   build-ee:
     outputs:
-      push_success: ${{ steps.push_to_ghcr.outputs.push_success }}
+      push_success: ${{ steps.push_to_registry.outputs.push_success }}
     runs-on: ubuntu-latest
     environment: ${{ github.event_name }}
     steps:
@@ -78,10 +86,11 @@ jobs:
         run: pip install ansible-dev-tools
 
       - name: Define common environment variables
+        working-directory: ${{ inputs.working_directory }}
         run: |
           echo "EE=`yq -r '.options.tags[0]' 'execution-environment.yml'`" >> $GITHUB_ENV
           echo "EE_file=execution-environment.yml" >> $GITHUB_ENV
-          echo "IMAGE_REGISTRY=ghcr.io" >> $GITHUB_ENV
+          echo "IMAGE_REGISTRY=${{ inputs.registry }}" >> $GITHUB_ENV
 
       - name: Define environment variables for PR
         if: github.event_name == 'pull_request_target'
@@ -98,69 +107,111 @@ jobs:
         run: |
           echo $GITHUB_ENV
 
-      - name: Login to ghcr
+      - name: Detect Red Hat registry credentials
+        id: redhat_registry
+        env:
+          REGISTRY_REDHAT_USERNAME: ${{ secrets.registry_redhat_username }}
+        run: |
+          if [[ -n "$REGISTRY_REDHAT_USERNAME" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Login to registry.redhat.io
+        if: steps.redhat_registry.outputs.enabled == 'true'
         uses: redhat-actions/podman-login@v1
         with:
-          registry: ${{ env.IMAGE_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: registry.redhat.io
+          username: ${{ secrets.registry_redhat_username }}
+          password: ${{ secrets.registry_redhat_password }}
 
       - name: (devel) Build image and create artifact
+        working-directory: ${{ inputs.working_directory }}
         run: |
           echo "Would build: ${{ env.EE }}"
 
       - name: Build image and create artifact
+        working-directory: ${{ inputs.working_directory }}
         run: |
           ansible-builder build -v 3 \
-          --build-arg AH_TOKEN=${{ secrets.AH_TOKEN }} \
-          --context=../${{ env.EE }} \
+          --build-arg AH_TOKEN=${{ secrets.ah_token }} \
           --tag=${{ env.EE }}:${{ env.IMAGE_TAG }} \
           --tag=${{ env.EE }}:${{ github.sha }}
 
+          # Artifact generation is informational; do not fail the job on diagnostic errors
+          set +e
+
           # Create artifact file
           COMMANDS_FILE="commands-${{ env.EE }}.txt"
-          echo "" >> $COMMANDS_FILE
-          echo "EE: ${{ env.EE }}" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "\`\`\`" > $COMMANDS_FILE
-          echo "podman pull ${{ env.EE }}:${{ env.IMAGE_TAG }}" >> $COMMANDS_FILE
-          echo "\`\`\`" >> $COMMANDS_FILE
-          echo "<details>" >> $COMMANDS_FILE
-          echo "<summary><b>More info...</b></summary>" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "#### Installed collections" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "\`\`\`" >> $COMMANDS_FILE
-          podman run -it ${{ env.EE }}:${{ env.IMAGE_TAG }} ansible-galaxy collection list  >> $COMMANDS_FILE
-          echo "\`\`\`" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "#### EE Testing" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "\`\`\`" >> $COMMANDS_FILE
-          echo "Installed collections" >> $COMMANDS_FILE
-          ansible-navigator collections --eei ${{ env.EE }}:${{ env.IMAGE_TAG }} --mode stdout --pp never | grep "known_as" >> $COMMANDS_FILE
-          echo "\`\`\`" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "\`\`\`" >> $COMMANDS_FILE
-          echo "Installed images" >> $COMMANDS_FILE
-          ansible-navigator images --eei ${{ env.EE }}:${{ env.IMAGE_TAG }} --mode stdout --pp never | grep "name_tag" >> $COMMANDS_FILE
-          echo "\`\`\`" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "#### Ansible version" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "\`\`\`" >> $COMMANDS_FILE
-          podman run -it ${{ env.EE }}:${{ env.IMAGE_TAG }} ansible --version  >> $COMMANDS_FILE
-          echo "\`\`\`" >> $COMMANDS_FILE
-          echo "</details>" >> $COMMANDS_FILE
+          echo "EE: ${{ env.EE }}" > "$COMMANDS_FILE"
+          echo "" >> "$COMMANDS_FILE"
+          echo "\`\`\`" >> "$COMMANDS_FILE"
+          echo "podman pull ${{ env.EE }}:${{ env.IMAGE_TAG }}" >> "$COMMANDS_FILE"
+          echo "\`\`\`" >> "$COMMANDS_FILE"
+          echo "<details>" >> "$COMMANDS_FILE"
+          echo "<summary><b>More info...</b></summary>" >> "$COMMANDS_FILE"
+          echo "" >> "$COMMANDS_FILE"
+          echo "#### Installed collections" >> "$COMMANDS_FILE"
+          echo "" >> "$COMMANDS_FILE"
+          echo "\`\`\`" >> "$COMMANDS_FILE"
+          podman run --rm ${{ env.EE }}:${{ env.IMAGE_TAG }} bash -c '
+            for collections_path in /usr/share/ansible/collections /home/runner/.ansible/collections; do
+              if find "${collections_path}/ansible_collections" -mindepth 2 -maxdepth 2 -type d 2>/dev/null | grep -q .; then
+                ansible-galaxy collection list -p "${collections_path}" || echo "Unable to list collections"
+                exit 0
+              fi
+            done
+            echo "No collections installed"
+          ' >> "$COMMANDS_FILE" 2>&1 || true
+          echo "\`\`\`" >> "$COMMANDS_FILE"
+          echo "" >> "$COMMANDS_FILE"
+          echo "#### EE Testing" >> "$COMMANDS_FILE"
+          echo "" >> "$COMMANDS_FILE"
+          echo "\`\`\`" >> "$COMMANDS_FILE"
+          echo "Installed collections" >> "$COMMANDS_FILE"
+          podman run --rm ${{ env.EE }}:${{ env.IMAGE_TAG }} bash -c '
+            for collections_path in /usr/share/ansible/collections /home/runner/.ansible/collections; do
+              if find "${collections_path}/ansible_collections" -mindepth 2 -maxdepth 2 -type d 2>/dev/null | grep -q .; then
+                find "${collections_path}/ansible_collections" -mindepth 2 -maxdepth 2 -type d \
+                  | sed "s|.*/ansible_collections/||" \
+                  | tr "/" "."
+                exit 0
+              fi
+            done
+            echo "No collections installed"
+          ' >> "$COMMANDS_FILE" 2>&1 || true
+          echo "\`\`\`" >> "$COMMANDS_FILE"
+          echo "" >> "$COMMANDS_FILE"
+          echo "\`\`\`" >> "$COMMANDS_FILE"
+          echo "Installed images" >> "$COMMANDS_FILE"
+          podman images --format "{{.Repository}}:{{.Tag}}" | grep "^${{ env.EE }}:" >> "$COMMANDS_FILE" 2>&1 || true
+          echo "\`\`\`" >> "$COMMANDS_FILE"
+          echo "" >> "$COMMANDS_FILE"
+          echo "#### Ansible version" >> "$COMMANDS_FILE"
+          echo "" >> "$COMMANDS_FILE"
+          echo "\`\`\`" >> "$COMMANDS_FILE"
+          podman run --rm ${{ env.EE }}:${{ env.IMAGE_TAG }} ansible --version >> "$COMMANDS_FILE" 2>&1 || true
+          echo "\`\`\`" >> "$COMMANDS_FILE"
+          echo "</details>" >> "$COMMANDS_FILE"
+
+          set -e
 
       - name: Upload build artifact
         uses: coactions/upload-artifact@v4
         with:
           name: commands-${{ env.EE }}
-          path: ./commands-${{ env.EE }}.txt
+          path: ${{ inputs.working_directory }}/commands-${{ env.EE }}.txt
 
-      - name: Push To GHCR
-        id: push_to_ghcr
+      - name: Login to container registry
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ secrets.registry_username }}
+          password: ${{ secrets.registry_password }}
+
+      - name: Push to container registry
+        id: push_to_registry
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ env.EE }}

--- a/.github/workflows/ee-build.yml
+++ b/.github/workflows/ee-build.yml
@@ -67,7 +67,7 @@ jobs:
 
   build-ee:
     outputs:
-      push_success: ${{ steps.push_to_registry.outputs.push_success }}
+      push_success: ${{ steps.set_push_success.outputs.push_success }}
     runs-on: ubuntu-latest
     environment: ${{ github.event_name }}
     steps:
@@ -133,9 +133,11 @@ jobs:
 
       - name: Build image and create artifact
         working-directory: ${{ inputs.working_directory }}
+        env:
+          AH_TOKEN: ${{ secrets.ah_token }}
         run: |
           ansible-builder build -v 3 \
-          --build-arg AH_TOKEN=${{ secrets.ah_token }} \
+          --build-arg AH_TOKEN="$AH_TOKEN" \
           --tag=${{ env.EE }}:${{ env.IMAGE_TAG }} \
           --tag=${{ env.EE }}:${{ github.sha }}
 
@@ -163,7 +165,7 @@ jobs:
               fi
             done
             echo "No collections installed"
-          ' >> "$COMMANDS_FILE" 2>&1 || true
+          ' >> "$COMMANDS_FILE" 2>&1
           echo "\`\`\`" >> "$COMMANDS_FILE"
           echo "" >> "$COMMANDS_FILE"
           echo "#### EE Testing" >> "$COMMANDS_FILE"
@@ -180,22 +182,20 @@ jobs:
               fi
             done
             echo "No collections installed"
-          ' >> "$COMMANDS_FILE" 2>&1 || true
+          ' >> "$COMMANDS_FILE" 2>&1
           echo "\`\`\`" >> "$COMMANDS_FILE"
           echo "" >> "$COMMANDS_FILE"
           echo "\`\`\`" >> "$COMMANDS_FILE"
           echo "Installed images" >> "$COMMANDS_FILE"
-          podman images --format "{{.Repository}}:{{.Tag}}" | grep "^${{ env.EE }}:" >> "$COMMANDS_FILE" 2>&1 || true
+          podman images --format "{{.Repository}}:{{.Tag}}" | grep "^${{ env.EE }}:" >> "$COMMANDS_FILE" 2>&1
           echo "\`\`\`" >> "$COMMANDS_FILE"
           echo "" >> "$COMMANDS_FILE"
           echo "#### Ansible version" >> "$COMMANDS_FILE"
           echo "" >> "$COMMANDS_FILE"
           echo "\`\`\`" >> "$COMMANDS_FILE"
-          podman run --rm ${{ env.EE }}:${{ env.IMAGE_TAG }} ansible --version >> "$COMMANDS_FILE" 2>&1 || true
+          podman run --rm ${{ env.EE }}:${{ env.IMAGE_TAG }} ansible --version >> "$COMMANDS_FILE" 2>&1
           echo "\`\`\`" >> "$COMMANDS_FILE"
           echo "</details>" >> "$COMMANDS_FILE"
-
-          set -e
 
       - name: Upload build artifact
         uses: coactions/upload-artifact@v4
@@ -219,8 +219,9 @@ jobs:
           registry: ${{ env.IMAGE_REGISTRY }}/${{ github.repository_owner }}
 
       - name: Set push success flag
+        id: set_push_success
         if: success()
-        run: echo "push_success=true" >> $GITHUB_ENV
+        run: echo "push_success=true" >> $GITHUB_OUTPUT
 
       - name: Print summary
         run: |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This combined GitHub Action covers the following action workflows:
 - Release Automation Hub - Push a release to Ansible Automation Hub only.
 - Draft Release - Generates changelog entries for release, also raises a PR with changelog and galaxy file updated.
 - Check Label - Check if a valid label added to the PR is required by the release drafter.
+- EE Build - Build and push Ansible Execution Environment images to a container registry.
 
 ## Licensing
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -196,7 +196,7 @@ For GitHub Container Registry, pass `${{ github.actor }}` and `${{ secrets.GITHU
 
 ### Single EE (repository root)
 
-Filename: `ee-build.yaml`
+Filename: `ee-build.yml`
 
 ```
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -170,3 +170,98 @@ The GitHub action uses tox-ansible which requires a tox-ansible.ini, a default t
 - `tests/integration/requirements.yml`
 - `tests/unit/requirements.yml`
 - [`galaxy.yml`](https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html)
+
+## The EE build workflow
+
+This reusable workflow builds an Ansible Execution Environment image from an `execution-environment.yml` file, pushes it to a container registry, and posts pull request comments with usage instructions.
+
+By default, the workflow looks for `execution-environment.yml` in the repository root. Use the `working_directory` input to build EEs that live in subdirectories, which enables matrix builds for monorepos with multiple execution environments.
+
+### Secrets
+
+| Secret                     | Required | Purpose                                                          |
+| -------------------------- | -------- | ---------------------------------------------------------------- |
+| `registry_username`        | yes      | Username for the destination registry login before push          |
+| `registry_password`        | yes      | Password or token for the destination registry login before push |
+| `registry_redhat_username` | no       | Username for `registry.redhat.io` login before build             |
+| `registry_redhat_password` | no       | Password or token for `registry.redhat.io` login before build    |
+| `ah_token`                 | no       | Automation Hub token passed to `ansible-builder` as `AH_TOKEN`   |
+
+The workflow performs two separate logins when needed:
+
+1. **Before build** — logs in to `registry.redhat.io` when Red Hat credentials are provided, so base images can be pulled during `ansible-builder build`.
+2. **Before push** — logs in to the destination registry from the `registry` input using `registry_username` and `registry_password`.
+
+For GitHub Container Registry, pass `${{ github.actor }}` and `${{ secrets.GITHUB_TOKEN }}` as the registry credentials.
+
+### Single EE (repository root)
+
+Filename: `ee-build.yaml`
+
+```
+---
+name: "Build execution environment"
+on:
+  pull_request_target:
+    branches: [main]
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+jobs:
+  build-ee:
+    uses: ansible/ansible-content-actions/.github/workflows/ee-build.yml@main
+    with:
+      registry: ghcr.io
+    secrets:
+      registry_username: ${{ github.actor }}
+      registry_password: ${{ secrets.GITHUB_TOKEN }}
+      registry_redhat_username: ${{ secrets.REGISTRY_REDHAT_USERNAME }}
+      registry_redhat_password: ${{ secrets.REGISTRY_REDHAT_PASSWORD }}
+      ah_token: ${{ secrets.AH_TOKEN }}
+```
+
+`registry_redhat_*` and `ah_token` are optional. Omit them when the build does not pull from Red Hat registries or install from Automation Hub.
+
+### Multiple EEs (matrix)
+
+For repositories that contain more than one execution environment, define a matrix caller workflow that passes each EE's folder path via `working_directory`.
+
+Filename: `build-all-ees.yaml`
+
+```
+---
+name: "Build all execution environments"
+on:
+  pull_request_target:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build-matrix:
+    name: Build ${{ matrix.ee-name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ee-name: network-ee
+            folder: ./network-ee
+          - ee-name: cloud-ee
+            folder: ./cloud-ee
+    uses: ansible/ansible-content-actions/.github/workflows/ee-build.yml@main
+    with:
+      registry: ghcr.io
+      working_directory: ${{ matrix.folder }}
+    secrets:
+      registry_username: ${{ github.actor }}
+      registry_password: ${{ secrets.GITHUB_TOKEN }}
+      registry_redhat_username: ${{ secrets.REGISTRY_REDHAT_USERNAME }}
+      registry_redhat_password: ${{ secrets.REGISTRY_REDHAT_PASSWORD }}
+      ah_token: ${{ secrets.AH_TOKEN }}
+```
+
+`registry_redhat_*` and `ah_token` are optional. Omit them when the build does not pull from Red Hat registries or install from Automation Hub.
+
+Each matrix entry runs an independent build against the `execution-environment.yml` in its folder. Artifacts are named per EE image tag, so pull request comments list every built image.


### PR DESCRIPTION
## Summary

This PR adds matrix/monorepo support to the EE build reusable workflow and fixes several pre-existing issues where declared inputs and secrets were ignored.

### New capability

- Add optional `working_directory` input so `execution-environment.yml` can live in subdirectories
- Run `yq` and `ansible-builder` from the configured directory, enabling matrix caller workflows for repos with multiple EEs
- Document single-EE and matrix caller workflow examples in `docs/usage.md`

### Bugs fixed in the previous workflow

- **`registry` input was ignored** — `IMAGE_REGISTRY` was hardcoded to `ghcr.io` even though callers could pass a different registry
- **Destination registry secrets were unused** — `registry_username` and `registry_password` were required workflow secrets but the login step used `github.actor` and `GITHUB_TOKEN` instead
- **Red Hat registry secrets were unused** — `registry_redhat_username` and `registry_redhat_password` were declared but never wired to a login, so private base image pulls from `registry.redhat.io` during build could fail
- **`AH_TOKEN` was undeclared** — `ansible-builder` referenced `secrets.AH_TOKEN` but it was not defined under `workflow_call.secrets`

### How login works now

1. **Before build** — optionally log in to `registry.redhat.io` when Red Hat credentials are provided
2. **Before push** — log in to the destination registry from the `registry` input using `registry_username` and `registry_password`

## Test plan

- [ ] Verify single-EE caller workflow (default `working_directory: '.'`) still builds from repo root
- [ ] Verify matrix caller workflow builds each EE from its subdirectory
- [ ] Confirm artifacts upload from the correct path when `working_directory` is set
- [ ] Confirm `IMAGE_REGISTRY` reflects the `registry` input value
- [ ] Confirm destination registry login uses `registry_username` / `registry_password`
- [ ] Confirm optional Red Hat registry login runs when `registry_redhat_*` secrets are provided
- [ ] Confirm `ah_token` is accepted and passed to `ansible-builder` as `AH_TOKEN`