### PR TITLE
fix: restore full repo path for self-referencing actions in reusable workflows

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -14,5 +14,4 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha }}"
           fetch-depth: "0"
       - name: Validate changelog
-        uses: >-
-          ./.github/actions/ansible_validate_changelog
+        uses: ansible/ansible-content-actions/.github/actions/ansible_validate_changelog@4d3858fdf3d9bd4cdbc69d6217dd1cd944a7609e # main

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: "3.14"
       - name: "Check for tox-ansible.ini file, else add default"
-        uses: ./.github/actions/add_tox_ansible
+        uses: ansible/ansible-content-actions/.github/actions/add_tox_ansible@4d3858fdf3d9bd4cdbc69d6217dd1cd944a7609e # main
       - name: "Install tox-ansible, includes tox"
         run: "python -m pip install git+https://github.com/ansible/tox-ansible.git"
       - name: Generate matrix
@@ -63,7 +63,7 @@ jobs:
         with:
           python-version: "${{ matrix.entry.python }}"
       - name: "Check for tox-ansible.ini file, else add default"
-        uses: ./.github/actions/add_tox_ansible
+        uses: ansible/ansible-content-actions/.github/actions/add_tox_ansible@4d3858fdf3d9bd4cdbc69d6217dd1cd944a7609e # main
       - name: "Install tox-ansible, includes tox"
         run: python -m pip install tox-ansible
       - name: Install build toolchain and openssl headers on Linux

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: "Install tox-ansible, includes tox"
         run: "python -m pip install tox-ansible"
       - name: "Check for tox-ansible.ini file, else add default"
-        uses: ./.github/actions/add_tox_ansible
+        uses: ansible/ansible-content-actions/.github/actions/add_tox_ansible@4d3858fdf3d9bd4cdbc69d6217dd1cd944a7609e # main
       - name: Generate matrix
         id: generate-matrix
         run: >
@@ -83,7 +83,7 @@ jobs:
       - name: "Install tox-ansible, includes tox"
         run: python -m pip install tox-ansible
       - name: "Check for tox-ansible.ini file, else add default"
-        uses: ./.github/actions/add_tox_ansible
+        uses: ansible/ansible-content-actions/.github/actions/add_tox_ansible@4d3858fdf3d9bd4cdbc69d6217dd1cd944a7609e # main
       - name: Run tox sanity tests
         run: >-
           python -m tox --ansible -e ${{ matrix.entry.name }} --conf

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: "3.14"
       - name: "Check for tox-ansible.ini file, else add default"
-        uses: ./.github/actions/add_tox_ansible
+        uses: ansible/ansible-content-actions/.github/actions/add_tox_ansible@4d3858fdf3d9bd4cdbc69d6217dd1cd944a7609e # main
       - name: "Install tox-ansible, includes tox"
         run: "python -m pip install tox-ansible"
       - name: Generate matrix
@@ -86,7 +86,7 @@ jobs:
       - name: "Install tox-ansible, includes tox"
         run: python -m pip install tox-ansible
       - name: "Check for tox-ansible.ini file, else add default"
-        uses: ./.github/actions/add_tox_ansible
+        uses: ansible/ansible-content-actions/.github/actions/add_tox_ansible@4d3858fdf3d9bd4cdbc69d6217dd1cd944a7609e # main
       - name: Install build toolchain and openssl headers on Linux
         shell: bash
         run: sudo apt update && sudo apt install build-essential libssl-dev


### PR DESCRIPTION


Local path references (./.github/actions/...) only resolve against the repository that triggers the workflow. When external collections call reusable workflows from ansible-content-actions, the runner looks for the action files inside the calling collection's checkout — not inside ansible-content-actions — causing "Can't find action.yml" errors.

Replace local paths with the full ansible/ansible-content-actions/... path pinned to the current HEAD SHA so the action is always fetched from the correct repository.

Fixes: ansible/ansible-content-actions/.github/actions/add_tox_ansible
Fixes: ansible/ansible-content-actions/.github/actions/ansible_validate_changelog